### PR TITLE
Implement Copy for ChunkId so they can be used many times

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use std::io::SeekFrom;
 use std::convert::TryInto;
 
 /// A chunk id, also known as FourCC
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub struct ChunkId {
   /// The raw bytes of the id
   pub value: [u8; 4]


### PR DESCRIPTION
For example RIFF_ID needs this to work in the README example.